### PR TITLE
#5 호버 기능 구현

### DIFF
--- a/src/components/Chart/CombinedChart.tsx
+++ b/src/components/Chart/CombinedChart.tsx
@@ -10,6 +10,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
+import CustomTooltip from './CustomTooltip';
+
 type CombinedChartDataType = {
   id: string;
   time: string;
@@ -47,7 +49,7 @@ const CombinedChart = ({ data }: CombinedChartProps) => {
         <CartesianGrid stroke="#f5f5f5" />
         <XAxis
           dataKey="time"
-          label={{ value: '시각', position: 'bottom', offset: -5 }}
+          label={{ value: 'Time', position: 'bottom', offset: -5 }}
           tickFormatter={formatDateStringToTime}
         />
         <YAxis
@@ -65,7 +67,7 @@ const CombinedChart = ({ data }: CombinedChartProps) => {
           orientation="right"
           yAxisId="area"
         />
-        <Tooltip />
+        <Tooltip content={CustomTooltip} />
         <Legend height={36} verticalAlign="top" />
         <Bar barSize={20} dataKey="value_bar" fill="#85df89" yAxisId="bar" />
         <Area dataKey="value_area" fill="#5e31d1" stroke="#5e31d1" type="monotone" yAxisId="area" />

--- a/src/components/Chart/CustomTooltip.tsx
+++ b/src/components/Chart/CustomTooltip.tsx
@@ -1,0 +1,19 @@
+import { TooltipProps } from 'recharts';
+
+const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>) => {
+  if (active && payload && label) {
+    const id = payload[0].payload.id;
+
+    return (
+      <div>
+        <p>{`id : ${id}`}</p>
+        {payload.map((item) => (
+          <p key={item.dataKey}>{`${item.dataKey} : ${item.value}`}</p>
+        ))}
+        <p>{`time: ${label}`}</p>
+      </div>
+    );
+  }
+};
+
+export default CustomTooltip;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import CombinedChart from '../components/CombinedChart';
+import CombinedChart from '../components/Chart/CombinedChart';
 import mockData from '../data/mock_data.json';
 
 const MainPage = () => {


### PR DESCRIPTION
# Description

호버 시 툴팁 구현

# Changes

- `CustomTooltip` 컴포넌트 생성
- 차트에 마우스 호버 시 `id`, `value_area`, `value_bar`를 포함한 데이터 툴팁 형태로 제공

## Attachment

![image](https://github.com/5unk3n/chart/assets/97281800/1cf18179-28ec-4c5c-989e-ae417aba20d4)

